### PR TITLE
add missing semi-colons in musichistory.sql

### DIFF
--- a/orientation/resources/assets/musichistory.sql
+++ b/orientation/resources/assets/musichistory.sql
@@ -453,14 +453,14 @@ JOIN Genre g ON s.GenreId = g.GenreId;
 /* List all songs with album information */
 SELECT a.Title 'Album', s.Title 'Song'
 From Song s
-left join Album a on s.AlbumId = a.AlbumId
+left join Album a on s.AlbumId = a.AlbumId;
 
 
 /* Find Albums with no songs */
 select a.Title 'Album', s.Title 'Song'
 from Album a
 left join Song s on s.AlbumId = a.AlbumId
-where s.Title is null
+where s.Title is null;
 
 
 


### PR DESCRIPTION
At the very bottom of the document, there were two statements that were missing semi-colons, preventing me from being able to create a database from this file. Added the semi-colons and it's working fine. 